### PR TITLE
Make build scan url pattern more strict

### DIFF
--- a/src/main/java/com/gradle/enterprise/bamboo/BuildScanLogScanner.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/BuildScanLogScanner.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 final class BuildScanLogScanner extends LogInterceptorAdapter {
 
     private static final Pattern BUILD_SCAN_PATTERN = Pattern.compile("Publishing (build scan|build information)\\.\\.\\.");
-    private static final Pattern URL_PATTERN = Pattern.compile("https?://\\S*");
+    private static final Pattern URL_PATTERN = Pattern.compile("https?://\\S*/s/\\S*");
 
     private static final int LOOK_AHEAD_LINES = 10;
 

--- a/src/test/java/com/gradle/enterprise/bamboo/BuildScanLogScannerTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/BuildScanLogScannerTest.java
@@ -19,8 +19,16 @@ public class BuildScanLogScannerTest {
         new BuildScanLogScanner(new BuildScanCollector(buildContext));
 
     @Test
-    void buildScanIsNotCollected() {
+    void buildScanIsNotCollectedAsItsNotPresentInLogs() {
         buildScanLogScanner.intercept(new BuildOutputLogEntry("log without build scan data"));
+
+        assertThat(buildContext.getCurrentResult().getCustomBuildData().containsKey(Constants.BUILD_SCANS_KEY), is(false));
+    }
+
+    @Test
+    void buildScanIsNotCollectedDueToNonBuildScanUrlType() {
+        buildScanLogScanner.intercept(new BuildOutputLogEntry("log without build scan data"));
+        buildScanLogScanner.intercept(new BuildOutputLogEntry("http://non-buildscan.url/"));
 
         assertThat(buildContext.getCurrentResult().getCustomBuildData().containsKey(Constants.BUILD_SCANS_KEY), is(false));
     }
@@ -30,6 +38,20 @@ public class BuildScanLogScannerTest {
         String buildScanUrl = TestFixtures.randomBuildScanUrl();
 
         buildScanLogScanner.intercept(new BuildOutputLogEntry("Publishing build scan..."));
+        buildScanLogScanner.intercept(new BuildOutputLogEntry(buildScanUrl));
+
+        assertThat(
+            buildContext.getCurrentResult().getCustomBuildData().get(Constants.BUILD_SCANS_KEY),
+            is(equalTo(buildScanUrl))
+        );
+    }
+
+    @Test
+    void buildScanIsCollectedAndNonBuildScanUrlIsIgnored() {
+        String buildScanUrl = TestFixtures.randomBuildScanUrl();
+
+        buildScanLogScanner.intercept(new BuildOutputLogEntry("Publishing build scan..."));
+        buildScanLogScanner.intercept(new BuildOutputLogEntry("http://non-buildscan.url/"));
         buildScanLogScanner.intercept(new BuildOutputLogEntry(buildScanUrl));
 
         assertThat(


### PR DESCRIPTION
The URL pattern we had accepted all kinds of different urls, which could lead to non-build scan urls appearing on the Build Scan Links page.

This PR makes the pattern more strict.