### PR TITLE
Use wildcard to ignore bamboo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "com.atlassian.bamboo:atlassian-bamboo-*"
       - dependency-name: "com.atlassian.plugin:atlassian-spring-scanner-annotation"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "com.atlassian.bamboo:atlassian-bamboo-web"
-      - dependency-name: "com.atlassian.bamboo:atlassian-bamboo-api"
-      - dependency-name: "com.atlassian.bamboo:atlassian-bamboo-core"
+      - dependency-name: "com.atlassian.bamboo:atlassian-bamboo-*"
       - dependency-name: "com.atlassian.plugin:atlassian-spring-scanner-annotation"
       - dependency-name: "org.mockito:mockito-core" # requires Java 11
       - dependency-name: "com.google.code.gson:gson" # should be fixed to work with Bamboo 6.x


### PR DESCRIPTION
Simplify a little bit exclude. Check for changes less frequently. 