### PR TITLE
Set `gradle.enterprise.externally-applied` before applying GE plugin

### DIFF
--- a/src/main/resources/gradle-enterprise/gradle/gradle-enterprise-init-script.gradle
+++ b/src/main/resources/gradle-enterprise/gradle/gradle-enterprise-init-script.gradle
@@ -89,7 +89,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (!scanPluginComponent) {
                     logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                    pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
+                    applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
@@ -115,7 +115,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
                 logger.quiet("Applying $GRADLE_ENTERPRISE_PLUGIN_CLASS via init script")
                 logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
+                applyPluginExternally(settings.pluginManager, GRADLE_ENTERPRISE_PLUGIN_CLASS)
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
@@ -158,4 +158,18 @@ static String escapeChar(char ch) {
 
 static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
     GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
+}
+
+void applyPluginExternally(PluginManager pluginManager, String pluginClassName) {
+    def oldValue = System.getProperty('gradle.enterprise.externally-applied')
+    System.setProperty('gradle.enterprise.externally-applied', 'true')
+    try {
+        pluginManager.apply(initscript.classLoader.loadClass(pluginClassName))
+    } finally {
+        if (oldValue == null) {
+            System.clearProperty('gradle.enterprise.externally-applied')
+        } else {
+            System.setProperty('gradle.enterprise.externally-applied', oldValue)
+        }
+    }
 }


### PR DESCRIPTION
In order for the Gradle Enterprise plugin to deactivate any potentially build-changing features (at the time of writing that means all of its testing features) when applied via the init script rather than directly in the build, the `gradle.enterprise.externally-applied` system property is now set before applying it and reset afterwards.