### PR TITLE
Update minimum supported Gradle Enterprise versions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,12 +96,12 @@ The following table shows the compatibility of the plugin version with Gradle En
 
 |===
 |Bamboo Plugin version  | Gradle Enterprise Maven extension version | Common Custom User Data Maven extension version  | Minimum supported Gradle Enterprise version
-|Next version           | 1.18.1                                    | 1.12.2                                           | 2022.3
-|1.2.0                  | 1.18.1                                    | 1.12.2                                           | 2022.3
-|1.1.2                  | 1.18.1                                    | 1.12.2                                           | 2022.3
-|1.1.1                  | 1.17.4                                    | 1.12.1                                           | 2022.3
-|1.1.0                  | 1.16.6                                    | 1.11.1                                           | 2022.3
-|1.0.0                  | 1.16.4                                    | 1.11.1                                           | 2022.3
+|Next version           | 1.18.1                                    | 1.12.2                                           | 2023.2
+|1.2.0                  | 1.18.1                                    | 1.12.2                                           | 2023.2
+|1.1.2                  | 1.18.1                                    | 1.12.2                                           | 2023.2
+|1.1.1                  | 1.17.4                                    | 1.12.1                                           | 2023.1
+|1.1.0                  | 1.16.6                                    | 1.11.1                                           | 2022.4
+|1.0.0                  | 1.16.4                                    | 1.11.1                                           | 2022.4
 |===
 
 == License


### PR DESCRIPTION
Updates the compatibility matrix according [to this manual](https://docs.gradle.com/enterprise/compatibility/#gradle_enterprise_compatibility_2).