### PR TITLE
Fix potential ClassCastException when upgrading/re-installing the plugin

### DIFF
--- a/src/main/java/com/gradle/enterprise/bamboo/config/ConfigurationMigrator.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/config/ConfigurationMigrator.java
@@ -19,12 +19,10 @@ public class ConfigurationMigrator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationMigrator.class);
     private static final String GRADLE_ENTERPRISE_BAMBOO_PLUGIN_KEY = "com.gradle.enterprise.gradle-enterprise-bamboo-plugin";
     private final BandanaManager bandanaManager;
-    private final JsonConfigurationConverter jsonConfigurationConverter;
 
     @Autowired
-    public ConfigurationMigrator(BandanaManager bandanaManager, JsonConfigurationConverter jsonConfigurationConverter) {
+    public ConfigurationMigrator(BandanaManager bandanaManager) {
         this.bandanaManager = bandanaManager;
-        this.jsonConfigurationConverter = jsonConfigurationConverter;
     }
 
     @EventListener
@@ -40,7 +38,7 @@ public class ConfigurationMigrator {
             try {
                 LOGGER.info("Migrating {} config from {} to {}", GRADLE_ENTERPRISE_BAMBOO_PLUGIN_KEY,
                     CONFIG_V0_KEY, CONFIG_V1_KEY);
-                String json = jsonConfigurationConverter.toJson(value);
+                String json = JsonConfigurationConverter.toJson(value);
                 bandanaManager.setValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, CONFIG_V1_KEY, json);
                 bandanaManager.removeValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, CONFIG_V0_KEY);
             } catch (JsonProcessingException e) {

--- a/src/main/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverter.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverter.java
@@ -11,20 +11,19 @@ import java.io.IOException;
 @Component
 public class JsonConfigurationConverter {
 
-    private final ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-    public JsonConfigurationConverter() {
-        objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    }
-
-    public @Nullable String toJson(@Nullable Object configuration) throws JsonProcessingException {
+    @Nullable
+    String toJson(@Nullable Object configuration) throws JsonProcessingException {
         if (configuration == null) {
             return null;
         }
         return objectMapper.writeValueAsString(configuration);
     }
 
-    public @Nullable PersistentConfiguration fromJson(@Nullable String json) throws IOException {
+    @Nullable
+    PersistentConfiguration fromJson(@Nullable String json) throws IOException {
         if (json == null) {
             return null;
         }

--- a/src/main/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverter.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverter.java
@@ -4,18 +4,19 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jetbrains.annotations.Nullable;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-@Component
-public class JsonConfigurationConverter {
+class JsonConfigurationConverter {
 
-    private final ObjectMapper objectMapper = new ObjectMapper()
+    private static final ObjectMapper objectMapper = new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    private JsonConfigurationConverter() {
+    }
+
     @Nullable
-    String toJson(@Nullable Object configuration) throws JsonProcessingException {
+    static String toJson(@Nullable Object configuration) throws JsonProcessingException {
         if (configuration == null) {
             return null;
         }
@@ -23,7 +24,7 @@ public class JsonConfigurationConverter {
     }
 
     @Nullable
-    PersistentConfiguration fromJson(@Nullable String json) throws IOException {
+    static PersistentConfiguration fromJson(@Nullable String json) throws IOException {
         if (json == null) {
             return null;
         }

--- a/src/main/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverter.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverter.java
@@ -1,0 +1,33 @@
+package com.gradle.enterprise.bamboo.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JsonConfigurationConverter {
+
+    private final ObjectMapper objectMapper;
+
+    public JsonConfigurationConverter() {
+        objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    public @Nullable String toJson(@Nullable Object configuration) throws JsonProcessingException {
+        if (configuration == null) {
+            return null;
+        }
+        return objectMapper.writeValueAsString(configuration);
+    }
+
+    public @Nullable PersistentConfiguration fromJson(@Nullable String json) throws IOException {
+        if (json == null) {
+            return null;
+        }
+        return objectMapper.readValue(json, PersistentConfiguration.class);
+    }
+}

--- a/src/main/java/com/gradle/enterprise/bamboo/config/PersistentConfiguration.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/config/PersistentConfiguration.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
+
 public class PersistentConfiguration {
 
     @Nullable
@@ -111,5 +113,25 @@ public class PersistentConfiguration {
             .append("injectMavenExtension", injectMavenExtension)
             .append("injectCcudExtension", injectCcudExtension)
             .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PersistentConfiguration that = (PersistentConfiguration) o;
+        return allowUntrustedServer == that.allowUntrustedServer &&
+            injectMavenExtension == that.injectMavenExtension &&
+            injectCcudExtension == that.injectCcudExtension && Objects.equals(server, that.server) &&
+            Objects.equals(sharedCredentialName, that.sharedCredentialName) &&
+            Objects.equals(gePluginVersion, that.gePluginVersion) &&
+            Objects.equals(ccudPluginVersion, that.ccudPluginVersion) &&
+            Objects.equals(pluginRepository, that.pluginRepository);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(server, allowUntrustedServer, sharedCredentialName, gePluginVersion, ccudPluginVersion,
+            pluginRepository, injectMavenExtension, injectCcudExtension);
     }
 }

--- a/src/main/java/com/gradle/enterprise/bamboo/config/PersistentConfigurationManager.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/config/PersistentConfigurationManager.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Component
 public class PersistentConfigurationManager {
 
-    static final String LEGACY_CONFIG_V0_KEY = "com.gradle.bamboo.plugins.ge.config";
+    static final String CONFIG_V0_KEY = "com.gradle.bamboo.plugins.ge.config";
     static final String CONFIG_V1_KEY = "com.gradle.bamboo.plugins.ge.config.v1";
     static final String CURRENT_CONFIG_KEY = CONFIG_V1_KEY;
     private final JsonConfigurationConverter jsonConfigurationConverter;

--- a/src/main/java/com/gradle/enterprise/bamboo/config/PersistentConfigurationManager.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/config/PersistentConfigurationManager.java
@@ -16,19 +16,17 @@ public class PersistentConfigurationManager {
     static final String CONFIG_V0_KEY = "com.gradle.bamboo.plugins.ge.config";
     static final String CONFIG_V1_KEY = "com.gradle.bamboo.plugins.ge.config.v1";
     static final String CURRENT_CONFIG_KEY = CONFIG_V1_KEY;
-    private final JsonConfigurationConverter jsonConfigurationConverter;
 
     private final BandanaManager bandanaManager;
 
     @Autowired
-    public PersistentConfigurationManager(@ComponentImport BandanaManager bandanaManager, JsonConfigurationConverter jsonConfigurationConverter) {
+    public PersistentConfigurationManager(@ComponentImport BandanaManager bandanaManager) {
         this.bandanaManager = bandanaManager;
-        this.jsonConfigurationConverter = jsonConfigurationConverter;
     }
 
     public void save(PersistentConfiguration configuration) {
         try {
-            bandanaManager.setValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, CURRENT_CONFIG_KEY, jsonConfigurationConverter.toJson(configuration));
+            bandanaManager.setValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, CURRENT_CONFIG_KEY, JsonConfigurationConverter.toJson(configuration));
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Error serializing configuration as json", e);
         }
@@ -37,9 +35,7 @@ public class PersistentConfigurationManager {
     public Optional<PersistentConfiguration> load() {
         try {
             Object value = bandanaManager.getValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, CURRENT_CONFIG_KEY);
-            return Optional.ofNullable(
-                jsonConfigurationConverter.fromJson((String) value)
-            );
+            return Optional.ofNullable(JsonConfigurationConverter.fromJson((String) value));
         } catch (IOException e) {
             throw new RuntimeException("Error deserializing configuration from json", e);
         }

--- a/src/main/java/com/gradle/enterprise/bamboo/config/PluginEnabledListener.java
+++ b/src/main/java/com/gradle/enterprise/bamboo/config/PluginEnabledListener.java
@@ -1,0 +1,47 @@
+package com.gradle.enterprise.bamboo.config;
+
+import com.atlassian.bamboo.bandana.PlanAwareBandanaContext;
+import com.atlassian.bandana.BandanaManager;
+import com.atlassian.event.api.EventListener;
+import com.atlassian.plugin.event.events.PluginEnabledEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PluginEnabledListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PluginEnabledListener.class);
+    private static final String PLUGIN_KEY = "com.gradle.enterprise.gradle-enterprise-bamboo-plugin";
+    private final BandanaManager bandanaManager;
+    private final JsonConfigurationConverter jsonConfigurationConverter;
+
+    @Autowired
+    public PluginEnabledListener(BandanaManager bandanaManager, JsonConfigurationConverter jsonConfigurationConverter) {
+        this.bandanaManager = bandanaManager;
+        this.jsonConfigurationConverter = jsonConfigurationConverter;
+    }
+
+    @EventListener
+    public void onPluginEnabled(PluginEnabledEvent event) {
+        if (PLUGIN_KEY.equals(event.getPlugin().getKey())) {
+            migrateLegacyConfigToV1();
+        }
+    }
+
+    private void migrateLegacyConfigToV1() {
+        Object value = bandanaManager.getValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, PersistentConfigurationManager.LEGACY_CONFIG_V0_KEY);
+        if (value != null && PersistentConfiguration.class.getName().equals(value.getClass().getName())) {
+            try {
+                LOGGER.info("Migrating {} config to json", PLUGIN_KEY);
+                String json = jsonConfigurationConverter.toJson(value);
+                bandanaManager.setValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, PersistentConfigurationManager.CONFIG_V1_KEY, json);
+                bandanaManager.removeValue(PlanAwareBandanaContext.GLOBAL_CONTEXT, PersistentConfigurationManager.LEGACY_CONFIG_V0_KEY);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Could not migrate config to json", e);
+            }
+        }
+    }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -10,6 +10,7 @@
 
     <!-- add our i18n resource -->
     <resource type="i18n" name="i18n" location="gradle-enterprise-bamboo-plugin"/>
+    <bambooEventListener key="pluginEnabledListener" class="com.gradle.enterprise.bamboo.config.PluginEnabledListener"/>
 
     <preJobAction key="gradleEnterprisePreJobAction"
                   name="Gradle Enterprise auto-injection preparation"

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -10,7 +10,7 @@
 
     <!-- add our i18n resource -->
     <resource type="i18n" name="i18n" location="gradle-enterprise-bamboo-plugin"/>
-    <bambooEventListener key="pluginEnabledListener" class="com.gradle.enterprise.bamboo.config.PluginEnabledListener"/>
+    <bambooEventListener key="pluginEnabledListener" class="com.gradle.enterprise.bamboo.config.ConfigurationMigrator"/>
 
     <preJobAction key="gradleEnterprisePreJobAction"
                   name="Gradle Enterprise auto-injection preparation"

--- a/src/test/java/com/gradle/enterprise/bamboo/GradleEnterprisePreJobActionTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/GradleEnterprisePreJobActionTest.java
@@ -8,7 +8,7 @@ import com.atlassian.bamboo.v2.build.BuildContext;
 import com.atlassian.bamboo.variable.VariableContext;
 import com.atlassian.bandana.BandanaContext;
 import com.atlassian.bandana.BandanaManager;
-import com.gradle.enterprise.bamboo.config.PersistentConfiguration;
+import com.gradle.enterprise.bamboo.config.JsonConfigurationConverter;
 import com.gradle.enterprise.bamboo.config.PersistentConfigurationManager;
 import com.gradle.enterprise.bamboo.config.UsernameAndPassword;
 import com.gradle.enterprise.bamboo.config.UsernameAndPasswordCredentialsProvider;
@@ -44,7 +44,7 @@ class GradleEnterprisePreJobActionTest {
 
     private final GradleEnterprisePreJobAction gradleEnterprisePreJobAction =
         new GradleEnterprisePreJobAction(
-            new PersistentConfigurationManager(bandanaManager),
+            new PersistentConfigurationManager(bandanaManager, new JsonConfigurationConverter()),
             new UsernameAndPasswordCredentialsProvider(credentialsAccessor),
             Collections.singletonList(gradleBuildScanInjector)
         );
@@ -63,7 +63,7 @@ class GradleEnterprisePreJobActionTest {
     void doesNothingIfNoSharedCredentials() {
         // given
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
-            .thenReturn(new PersistentConfiguration());
+            .thenReturn("{}");
 
         // when
         gradleEnterprisePreJobAction.execute(stageExecution, buildContext);
@@ -78,7 +78,7 @@ class GradleEnterprisePreJobActionTest {
         // given
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
-            .thenReturn(new PersistentConfiguration().setSharedCredentialName(credentialsName));
+            .thenReturn("{\"sharedCredentialName\":\"" + credentialsName + "\"}");
 
         // when
         gradleEnterprisePreJobAction.execute(stageExecution, buildContext);
@@ -97,7 +97,7 @@ class GradleEnterprisePreJobActionTest {
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
-            .thenReturn(new PersistentConfiguration().setSharedCredentialName(credentialsName));
+            .thenReturn("{\"sharedCredentialName\":\"" + credentialsName + "\"}");
         when(credentialsAccessor.getCredentialsByName(credentialsName))
             .thenReturn(credentialsData);
 
@@ -119,11 +119,9 @@ class GradleEnterprisePreJobActionTest {
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
-            .thenReturn(
-                new PersistentConfiguration()
-                    .setServer("https://scans.gradle.com")
-                    .setSharedCredentialName(credentialsName)
-                    .setGePluginVersion("3.12"));
+            .thenReturn("{\"server\":\"https://scans.gradle.com\",\"sharedCredentialName\":\"" + credentialsName + "\", " +
+                "\"gePluginVersion\": \"3.12\"}");
+
         when(credentialsAccessor.getCredentialsByName(credentialsName))
             .thenReturn(credentialsData);
 
@@ -150,10 +148,7 @@ class GradleEnterprisePreJobActionTest {
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
-            .thenReturn(
-                new PersistentConfiguration()
-                    .setServer("https://scans.gradle.com")
-                    .setSharedCredentialName(credentialsName));
+            .thenReturn("{\"server\":\"https://scans.gradle.com\",\"sharedCredentialName\":\"" + credentialsName + "\"}");
         when(credentialsAccessor.getCredentialsByName(credentialsName))
             .thenReturn(credentialsData);
 
@@ -188,11 +183,9 @@ class GradleEnterprisePreJobActionTest {
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
-            .thenReturn(
-                new PersistentConfiguration()
-                    .setServer("https://scans.gradle.com")
-                    .setSharedCredentialName(credentialsName)
-                    .setGePluginVersion("3.12"));
+            .thenReturn("{\"server\":\"https://scans.gradle.com\",\"sharedCredentialName\":\"" + credentialsName + "\", " +
+                "\"gePluginVersion\": \"3.12\"}");
+
         when(credentialsAccessor.getCredentialsByName(credentialsName))
             .thenReturn(credentialsData);
 

--- a/src/test/java/com/gradle/enterprise/bamboo/GradleEnterprisePreJobActionTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/GradleEnterprisePreJobActionTest.java
@@ -8,7 +8,6 @@ import com.atlassian.bamboo.v2.build.BuildContext;
 import com.atlassian.bamboo.variable.VariableContext;
 import com.atlassian.bandana.BandanaContext;
 import com.atlassian.bandana.BandanaManager;
-import com.gradle.enterprise.bamboo.config.JsonConfigurationConverter;
 import com.gradle.enterprise.bamboo.config.PersistentConfigurationManager;
 import com.gradle.enterprise.bamboo.config.UsernameAndPassword;
 import com.gradle.enterprise.bamboo.config.UsernameAndPasswordCredentialsProvider;
@@ -44,7 +43,7 @@ class GradleEnterprisePreJobActionTest {
 
     private final GradleEnterprisePreJobAction gradleEnterprisePreJobAction =
         new GradleEnterprisePreJobAction(
-            new PersistentConfigurationManager(bandanaManager, new JsonConfigurationConverter()),
+            new PersistentConfigurationManager(bandanaManager),
             new UsernameAndPasswordCredentialsProvider(credentialsAccessor),
             Collections.singletonList(gradleBuildScanInjector)
         );

--- a/src/test/java/com/gradle/enterprise/bamboo/config/ConfigurationMigratorTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/config/ConfigurationMigratorTest.java
@@ -13,7 +13,12 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ConfigurationMigratorTest {
 
@@ -21,7 +26,7 @@ class ConfigurationMigratorTest {
     private final PluginEnabledEvent pluginEnabledEvent = mock(PluginEnabledEvent.class);
 
     @Test
-    void runsMigrateConfigV0toV1() {
+    void runsMigrateConfigV0ToV1() {
         setupPluginEnabledEventMock("com.gradle.enterprise.gradle-enterprise-bamboo-plugin");
         when(bandanaManager.getValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config")))
             .thenReturn(new PersistentConfiguration().setServer("https://mycomp"));
@@ -35,7 +40,7 @@ class ConfigurationMigratorTest {
 
     @ParameterizedTest
     @MethodSource("configAndEventProvider")
-    void doesNotRunMigrateConfigV0toV1(Object config, String eventKey) {
+    void doesNotRunMigrateConfigV0ToV1(Object config, String eventKey) {
         setupPluginEnabledEventMock(eventKey);
         when(bandanaManager.getValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config")))
             .thenReturn(config);

--- a/src/test/java/com/gradle/enterprise/bamboo/config/ConfigurationMigratorTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/config/ConfigurationMigratorTest.java
@@ -26,7 +26,7 @@ class ConfigurationMigratorTest {
         when(bandanaManager.getValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config")))
             .thenReturn(new PersistentConfiguration().setServer("https://mycomp"));
 
-        new ConfigurationMigrator(bandanaManager, new JsonConfigurationConverter()).onPluginEnabled(pluginEnabledEvent);
+        new ConfigurationMigrator(bandanaManager).onPluginEnabled(pluginEnabledEvent);
 
         verify(bandanaManager, times(1)).setValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config.v1"),
             eq("{\"server\":\"https://mycomp\",\"allowUntrustedServer\":false,\"sharedCredentialName\":null,\"gePluginVersion\":null,\"ccudPluginVersion\":null,\"pluginRepository\":null,\"injectMavenExtension\":false,\"injectCcudExtension\":false}"));
@@ -40,7 +40,7 @@ class ConfigurationMigratorTest {
         when(bandanaManager.getValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config")))
             .thenReturn(config);
 
-        new ConfigurationMigrator(bandanaManager, new JsonConfigurationConverter()).onPluginEnabled(pluginEnabledEvent);
+        new ConfigurationMigrator(bandanaManager).onPluginEnabled(pluginEnabledEvent);
 
         verify(bandanaManager, times(0)).setValue(any(BandanaContext.class), anyString(), anyString());
         verify(bandanaManager, times(0)).removeValue(any(BandanaContext.class), anyString());

--- a/src/test/java/com/gradle/enterprise/bamboo/config/ConfigurationMigratorTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/config/ConfigurationMigratorTest.java
@@ -1,0 +1,63 @@
+package com.gradle.enterprise.bamboo.config;
+
+import com.atlassian.bandana.BandanaContext;
+import com.atlassian.bandana.BandanaManager;
+import com.atlassian.plugin.Plugin;
+import com.atlassian.plugin.event.events.PluginEnabledEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ConfigurationMigratorTest {
+
+    private final BandanaManager bandanaManager = mock(BandanaManager.class);
+    private final PluginEnabledEvent pluginEnabledEvent = mock(PluginEnabledEvent.class);
+
+    @Test
+    void runsMigrateConfigV0toV1() {
+        setupPluginEnabledEventMock("com.gradle.enterprise.gradle-enterprise-bamboo-plugin");
+        when(bandanaManager.getValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config")))
+            .thenReturn(new PersistentConfiguration().setServer("https://mycomp"));
+
+        new ConfigurationMigrator(bandanaManager, new JsonConfigurationConverter()).onPluginEnabled(pluginEnabledEvent);
+
+        verify(bandanaManager, times(1)).setValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config.v1"),
+            eq("{\"server\":\"https://mycomp\",\"allowUntrustedServer\":false,\"sharedCredentialName\":null,\"gePluginVersion\":null,\"ccudPluginVersion\":null,\"pluginRepository\":null,\"injectMavenExtension\":false,\"injectCcudExtension\":false}"));
+        verify(bandanaManager, times(1)).removeValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("configAndEventProvider")
+    void doesNotRunMigrateConfigV0toV1(Object config, String eventKey) {
+        setupPluginEnabledEventMock(eventKey);
+        when(bandanaManager.getValue(any(BandanaContext.class), eq("com.gradle.bamboo.plugins.ge.config")))
+            .thenReturn(config);
+
+        new ConfigurationMigrator(bandanaManager, new JsonConfigurationConverter()).onPluginEnabled(pluginEnabledEvent);
+
+        verify(bandanaManager, times(0)).setValue(any(BandanaContext.class), anyString(), anyString());
+        verify(bandanaManager, times(0)).removeValue(any(BandanaContext.class), anyString());
+    }
+
+    static Stream<Arguments> configAndEventProvider() {
+        return Stream.of(
+            arguments(null, "com.gradle.enterprise.gradle-enterprise-bamboo-plugin"),
+            arguments("not a Persistent Configuration object", "com.gradle.enterprise.gradle-enterprise-bamboo-plugin"),
+            arguments(new PersistentConfiguration(), "some.other.plugin")
+        );
+    }
+
+    private void setupPluginEnabledEventMock(String eventKey) {
+        Plugin pluginMock = mock(Plugin.class);
+        when(pluginMock.getKey()).thenReturn(eventKey);
+        when(pluginEnabledEvent.getPlugin()).thenReturn(pluginMock);
+    }
+
+}

--- a/src/test/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverterTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverterTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class JsonConfigurationConverterTest {

--- a/src/test/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverterTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverterTest.java
@@ -1,0 +1,55 @@
+package com.gradle.enterprise.bamboo.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JsonConfigurationConverterTest {
+
+    private static final PersistentConfiguration config = new PersistentConfiguration()
+        .setServer("https://mycompany.com")
+        .setGePluginVersion("3.11")
+        .setPluginRepository("https://plugins.mycompany.com")
+        .setSharedCredentialName("ge-creds")
+        .setAllowUntrustedServer(true)
+        .setCcudPluginVersion("1.11")
+        .setInjectCcudExtension(true)
+        .setInjectMavenExtension(true);
+
+    private static final String json = "{\"server\":\"https://mycompany.com\",\"allowUntrustedServer\":true," +
+        "\"sharedCredentialName\":\"ge-creds\",\"gePluginVersion\":\"3.11\",\"ccudPluginVersion\":\"1.11\"," +
+        "\"pluginRepository\":\"https://plugins.mycompany.com\",\"injectMavenExtension\":true," +
+        "\"injectCcudExtension\":true}";
+
+    @Test
+    void toJson() throws JsonProcessingException {
+        assertThat(new JsonConfigurationConverter().toJson(config), is(json));
+    }
+
+    @Test
+    void toNullJson() throws JsonProcessingException {
+        assertThat(new JsonConfigurationConverter().toJson(null), nullValue());
+    }
+
+    @Test
+    void fromJson() throws IOException {
+        assertThat(new JsonConfigurationConverter().fromJson(json), equalTo(config));
+    }
+
+    @Test
+    void fromNullJson() throws IOException {
+        assertThat(new JsonConfigurationConverter().fromJson(null), nullValue());
+    }
+
+    @Test
+    void unknownAttributesAreIgnored() throws IOException {
+        String jsonConfig = "{\"server\":\"https://mycompany.com\",\"foo\":\"bar\"}";
+
+        assertThat(new JsonConfigurationConverter().fromJson(jsonConfig),
+            equalTo(new PersistentConfiguration().setServer("https://mycompany.com")));
+    }
+}

--- a/src/test/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverterTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/config/JsonConfigurationConverterTest.java
@@ -27,29 +27,29 @@ class JsonConfigurationConverterTest {
 
     @Test
     void toJson() throws JsonProcessingException {
-        assertThat(new JsonConfigurationConverter().toJson(config), is(json));
+        assertThat(JsonConfigurationConverter.toJson(config), is(json));
     }
 
     @Test
     void toNullJson() throws JsonProcessingException {
-        assertThat(new JsonConfigurationConverter().toJson(null), nullValue());
+        assertThat(JsonConfigurationConverter.toJson(null), nullValue());
     }
 
     @Test
     void fromJson() throws IOException {
-        assertThat(new JsonConfigurationConverter().fromJson(json), equalTo(config));
+        assertThat(JsonConfigurationConverter.fromJson(json), equalTo(config));
     }
 
     @Test
     void fromNullJson() throws IOException {
-        assertThat(new JsonConfigurationConverter().fromJson(null), nullValue());
+        assertThat(JsonConfigurationConverter.fromJson(null), nullValue());
     }
 
     @Test
     void unknownAttributesAreIgnored() throws IOException {
         String jsonConfig = "{\"server\":\"https://mycompany.com\",\"foo\":\"bar\"}";
 
-        assertThat(new JsonConfigurationConverter().fromJson(jsonConfig),
+        assertThat(JsonConfigurationConverter.fromJson(jsonConfig),
             equalTo(new PersistentConfiguration().setServer("https://mycompany.com")));
     }
 }


### PR DESCRIPTION
More details: https://community.developer.atlassian.com/t/confluence-dc-throws-classcastexception-when-getting-object-from-bandana-after-app-upgrade/31894

The workaround taken here is to serialize/deserialize to a Json string in a new config key, it also set grounds for future potential config migrations.