### PR TITLE
Bumped Gradle Enterprise Maven Extension from 1.18.1 to 1.19

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,7 +96,7 @@ The following table shows the compatibility of the plugin version with Gradle En
 
 |===
 |Bamboo Plugin version  | Gradle Enterprise Maven extension version | Common Custom User Data Maven extension version  | Minimum supported Gradle Enterprise version
-|Next version           | 1.18.1                                    | 1.12.2                                           | 2023.2
+|Next version           | 1.19                                      | 1.12.2                                           | 2023.3
 |1.2.0                  | 1.18.1                                    | 1.12.2                                           | 2023.2
 |1.1.2                  | 1.18.1                                    | 1.12.2                                           | 2023.2
 |1.1.1                  | 1.17.4                                    | 1.12.1                                           | 2023.1

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
         <generated.java.sources.dir>${project.build.directory}/generated-sources/java</generated.java.sources.dir>
 
-        <ge.maven.extension.version>1.18.1</ge.maven.extension.version>
+        <ge.maven.extension.version>1.19</ge.maven.extension.version>
         <ccud.maven.extension.version>1.12.2</ccud.maven.extension.version>
     </properties>
 

--- a/src/test/java/com/gradle/enterprise/bamboo/MavenEmbeddedResourcesTest.java
+++ b/src/test/java/com/gradle/enterprise/bamboo/MavenEmbeddedResourcesTest.java
@@ -29,7 +29,7 @@ public class MavenEmbeddedResourcesTest {
      */
     @ParameterizedTest
     @CsvSource({
-            "GE_EXTENSION, c0c8bff8fe99e1579e1ad410b260673a",
+            "GE_EXTENSION, 28d395dea8a6825c7ebc24a10ab2f2e7",
             "CCUD_EXTENSION, d986e6377183b9283948abe8f89987a8"
     })
     void copiesEmbeddedExtension(MavenEmbeddedResources.Resource resource, String expectedChecksum) throws Exception {


### PR DESCRIPTION
Bumped Gradle Enterprise Maven Extension from 1.18.1 to 1.19. [Changelog](https://docs.gradle.com/enterprise/maven-extension/#release_history)